### PR TITLE
Fix File Descriptor Leak with Custom Resource Stream Wrapper

### DIFF
--- a/okio/src/jvmMain/kotlin/okio/FileSystem.kt
+++ b/okio/src/jvmMain/kotlin/okio/FileSystem.kt
@@ -61,11 +61,14 @@ actual abstract class FileSystem {
   @Throws(IOException::class)
   actual abstract fun source(file: Path): Source
 
+
   @Throws(IOException::class)
   @JvmName("-read")
   actual inline fun <T> read(file: Path, readerAction: BufferedSource.() -> T): T {
-    return source(file).buffer().use {
-      it.readerAction()
+    return source(file).buffer().use { bufferedSource ->
+      val result = bufferedSource.readerAction()
+      bufferedSource.close()
+      result
     }
   }
 

--- a/okio/src/jvmMain/kotlin/okio/internal/CustomResourceLoader.kt
+++ b/okio/src/jvmMain/kotlin/okio/internal/CustomResourceLoader.kt
@@ -1,0 +1,27 @@
+object CustomResourceLoader {
+
+  fun getResourceAsStream(classLoader: ClassLoader, resourceName: String): InputStream? {
+    val resourceURL = classLoader.getResource(resourceName) ?: return null
+    val connection = resourceURL.openConnection()
+
+    // Explicitly disable caching
+    connection.useCaches = false
+
+    return connection.getInputStream().let { CustomResourceInputStream(it) }
+  }
+
+  private class CustomResourceInputStream(inputStream: InputStream) : FilterInputStream(inputStream) {
+    override fun close() {
+      try {
+        super.close()
+      } finally {
+        // Ensure the underlying jar file is closed
+        (this.in as? JarURLConnection)?.jarFile?.close()
+      }
+    }
+  }
+}
+
+// Usage:
+val stream = CustomResourceLoader.getResourceAsStream(ClassLoader.getSystemClassLoader(), "path/to/resource")
+stream?.use { /* process the stream */ }


### PR DESCRIPTION
This pull request addresses the File Descriptor Leak issue in Okio's `FileSystem.read()` method. 

**Key Changes:**
- Introduced a Custom Resource Stream Wrapper that provides direct control over the `useCaches` flag of `JarURLConnection`.
- Modified the `read` function in `FileSystem.kt` so that InputStream is explicitly closed in FileSystem.read()."